### PR TITLE
Add a hyprland_toplevel_export_v1 protocol

### DIFF
--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -142,8 +142,6 @@
         summary="the object has already been used to copy a wl_buffer"/>
       <entry name="invalid_buffer" value="1"
         summary="buffer attributes are invalid"/>
-      <entry name="invalid_handle" value="2"
-        summary="the handle is invalid. The window may not exist or be unshareable (e.g. unmapped)"/>
     </enum>
 
     <enum name="flags" bitfield="true">

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -1,26 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="hyprland_toplevel_export_v1">
   <copyright>
-    Copyright © 2018 Vaxry
+    Copyright © 2022 Vaxry
+    All rights reserved.
 
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and associated documentation files (the "Software"),
-    to deal in the Software without restriction, including without limitation
-    the rights to use, copy, modify, merge, publish, distribute, sublicense,
-    and/or sell copies of the Software, and to permit persons to whom the
-    Software is furnished to do so, subject to the following conditions:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-    The above copyright notice and this permission notice (including the next
-    paragraph) shall be included in all copies or substantial portions of the
-    Software.
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-    DEALINGS IN THE SOFTWARE.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   </copyright>
 
   <description summary="capturing the contents of toplevel windows">

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="hyprland_toplevel_export_v1">
+  <copyright>
+    Copyright © 2018 Vaxry
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="capturing the contents of toplevel windows">
+    This protocol allows clients to ask for exporting another toplevel's
+    surface(s) to a buffer.
+
+    Particularly useful for sharing a single window.
+  </description>
+
+  <interface name="hyprland_toplevel_export_manager_v1" version="1">
+    <description summary="manager to inform clients and begin capturing">
+      This object is a manager which offers requests to start capturing from a
+      source.
+    </description>
+
+    <request name="capture_toplevel">
+      <description summary="capture a toplevel">
+        Capture the next frame of a toplevel.
+      </description>
+      <arg name="frame" type="new_id" interface="hyprland_toplevel_export_frame_v1"/>
+      <arg name="overlay_cursor" type="int"
+        summary="composite cursor onto the frame"/>
+      <arg name="handle" type="int" summary="the *hyprland* handle of a window to be captured"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="hyprland_toplevel_export_frame_v1" version="1">
+    <description summary="a frame ready for copy">
+      This object represents a single frame.
+
+      When created, a series of buffer events will be sent, each representing a
+      supported buffer type. The "buffer_done" event is sent afterwards to
+      indicate that all supported buffer types have been enumerated. The client
+      will then be able to send a "copy" request. If the capture is successful,
+      the compositor will send a "flags" followed by a "ready" event.
+
+      For objects version 2 or lower, wl_shm buffers are always supported, ie.
+      the "buffer" event is guaranteed to be sent.
+
+      If the capture failed, the "failed" event is sent. This can happen anytime
+      before the "ready" event.
+
+      Once either a "ready" or a "failed" event is received, the client should
+      destroy the frame.
+    </description>
+
+    <event name="buffer">
+      <description summary="wl_shm buffer information">
+        Provides information about wl_shm buffer parameters that need to be
+        used for this frame. This event is sent once after the frame is created
+        if wl_shm buffers are supported.
+      </description>
+      <arg name="format" type="uint" enum="wl_shm.format" summary="buffer format"/>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+      <arg name="stride" type="uint" summary="buffer stride"/>
+    </event>
+
+    <request name="copy">
+      <description summary="copy the frame">
+        Copy the frame to the supplied buffer. The buffer must have the
+        correct size, see hyprland_toplevel_export_frame_v1.buffer and
+        hyprland_toplevel_export_frame_v1.linux_dmabuf. The buffer needs to have a
+        supported format.
+
+        If the frame is successfully copied, a "flags" and a "ready" event is
+        sent. Otherwise, a "failed" event is sent.
+
+        This event will wait for appropriate damage to be copied, unless the ignore_damage
+        arg is set to a non-zero value.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+      <arg name="ignore_damage" type="int"/>
+    </request>
+
+    <event name="damage">
+      <description summary="carries the coordinates of the damaged region">
+        This event is sent right before the ready event when ignore_damage was
+        not set. It may be generated multiple times for each copy
+        request.
+
+        The arguments describe a box around an area that has changed since the
+        last copy request that was derived from the current screencopy manager
+        instance.
+
+        The union of all regions received between the call to copy
+        and a ready event is the total damage since the prior ready event.
+      </description>
+      <arg name="x" type="uint" summary="damaged x coordinates"/>
+      <arg name="y" type="uint" summary="damaged y coordinates"/>
+      <arg name="width" type="uint" summary="current width"/>
+      <arg name="height" type="uint" summary="current height"/>
+    </event>
+
+    <enum name="error">
+      <entry name="already_used" value="0"
+        summary="the object has already been used to copy a wl_buffer"/>
+      <entry name="invalid_buffer" value="1"
+        summary="buffer attributes are invalid"/>
+    </enum>
+
+    <enum name="flags" bitfield="true">
+      <entry name="y_invert" value="1" summary="contents are y-inverted"/>
+    </enum>
+
+    <event name="flags">
+      <description summary="frame flags">
+        Provides flags about the frame. This event is sent once before the
+        "ready" event.
+      </description>
+      <arg name="flags" type="uint" enum="flags" summary="frame flags"/>
+    </event>
+
+    <event name="ready">
+      <description summary="indicates frame is available for reading">
+        Called as soon as the frame is copied, indicating it is available
+        for reading. This event includes the time at which presentation happened
+        at.
+
+        The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
+        each component being an unsigned 32-bit value. Whole seconds are in
+        tv_sec which is a 64-bit value combined from tv_sec_hi and tv_sec_lo,
+        and the additional fractional part in tv_nsec as nanoseconds. Hence,
+        for valid timestamps tv_nsec must be in [0, 999999999]. The seconds part
+        may have an arbitrary offset at start.
+
+        After receiving this event, the client should destroy the object.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="failed">
+      <description summary="frame copy failed">
+        This event indicates that the attempted frame copy has failed.
+
+        After receiving this event, the client should destroy the object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Destroys the frame. This request can be sent at any time by the client.
+      </description>
+    </request>
+
+    <event name="linux_dmabuf">
+      <description summary="linux-dmabuf buffer information">
+        Provides information about linux-dmabuf buffer parameters that need to
+        be used for this frame. This event is sent once after the frame is
+        created if linux-dmabuf buffers are supported.
+      </description>
+      <arg name="format" type="uint" summary="fourcc pixel format"/>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+    </event>
+
+    <event name="buffer_done">
+      <description summary="all buffer types reported">
+        This event is sent once after all buffer events have been sent.
+
+        The client should proceed to create a buffer of one of the supported
+        types, and send a "copy" request.
+      </description>
+    </event>
+  </interface>
+</protocol>

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -64,8 +64,7 @@
       will then be able to send a "copy" request. If the capture is successful,
       the compositor will send a "flags" followed by a "ready" event.
 
-      For objects version 2 or lower, wl_shm buffers are always supported, ie.
-      the "buffer" event is guaranteed to be sent.
+      wl_shm buffers are always supported, ie. the "buffer" event is guaranteed to be sent.
 
       If the capture failed, the "failed" event is sent. This can happen anytime
       before the "ready" event.

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -142,6 +142,8 @@
         summary="the object has already been used to copy a wl_buffer"/>
       <entry name="invalid_buffer" value="1"
         summary="buffer attributes are invalid"/>
+      <entry name="invalid_handle" value="2"
+        summary="the handle is invalid. The window may not exist or be unshareable (e.g. unmapped)"/>
     </enum>
 
     <enum name="flags" bitfield="true">

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -38,12 +38,21 @@
 
     <request name="capture_toplevel">
       <description summary="capture a toplevel">
-        Capture the next frame of a toplevel.
+        Capture the next frame of a toplevel. (window)
+
+        The captured frame will not contain any server-side decorations and will
+        ignore the compositor-set geometry, like e.g. rounded corners.
+
+        It will contain all the subsurfaces and popups, however the latter will be clipped
+        to the geometry of the base surface.
+
+        The handle parameter refers to the address of the window as seen in `hyprctl clients`.
+        For example, for d161e7b0 it would be 3512854448.
       </description>
       <arg name="frame" type="new_id" interface="hyprland_toplevel_export_frame_v1"/>
       <arg name="overlay_cursor" type="int"
         summary="composite cursor onto the frame"/>
-      <arg name="handle" type="int" summary="the *hyprland* handle of a window to be captured"/>
+      <arg name="handle" type="uint" summary="the handle of the toplevel (window) to be captured"/>
     </request>
 
     <request name="destroy" type="destructor">


### PR DESCRIPTION
This is the first iteration of a protocol that will allow Hyprland (accompanied by xdg-desktop-portal-hyprland) to export toplevels for e.g. sharing.

I invite anyone interested to read the protocol suggestion and suggest changes.

Hyprland MR: https://github.com/hyprwm/Hyprland/pull/1179
XDPH MR: https://github.com/hyprwm/xdg-desktop-portal-hyprland/pull/2