### PR TITLE
hyprland_toplevel_export_v1: Revision 2

### DIFF
--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -77,7 +77,7 @@
       <arg name="frame" type="new_id" interface="hyprland_toplevel_export_frame_v1"/>
       <arg name="overlay_cursor" type="int"
         summary="composite cursor onto the frame"/>
-      <arg name="handle" type="object" allow-null="false" summary="the zwlr_foreign_toplevel_handle_v1 handle of the toplevel to be captured"/>
+      <arg name="handle" type="object" interface="zwlr_foreign_toplevel_handle_v1" allow-null="false" summary="the zwlr_foreign_toplevel_handle_v1 handle of the toplevel to be captured"/>
     </request>
     <!-- End Version 2 -->
   </interface>

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -37,7 +37,7 @@
     Particularly useful for sharing a single window.
   </description>
 
-  <interface name="hyprland_toplevel_export_manager_v1" version="1">
+  <interface name="hyprland_toplevel_export_manager_v1" version="2">
     <description summary="manager to inform clients and begin capturing">
       This object is a manager which offers requests to start capturing from a
       source.
@@ -70,7 +70,7 @@
     </request>
 
     <!-- Version 2 -->
-    <request name="capture_toplevel_with_wlr_toplevel_handle">
+    <request name="capture_toplevel_with_wlr_toplevel_handle" since="2">
       <description summary="capture a toplevel">
         Same as capture_toplevel, but with a zwlr_foreign_toplevel_handle_v1 handle.
       </description>
@@ -82,7 +82,7 @@
     <!-- End Version 2 -->
   </interface>
 
-  <interface name="hyprland_toplevel_export_frame_v1" version="1">
+  <interface name="hyprland_toplevel_export_frame_v1" version="2">
     <description summary="a frame ready for copy">
       This object represents a single frame.
 

--- a/protocols/hyprland-toplevel-export-v1.xml
+++ b/protocols/hyprland-toplevel-export-v1.xml
@@ -68,6 +68,18 @@
         appropriate destroy request has been called.
       </description>
     </request>
+
+    <!-- Version 2 -->
+    <request name="capture_toplevel_with_wlr_toplevel_handle">
+      <description summary="capture a toplevel">
+        Same as capture_toplevel, but with a zwlr_foreign_toplevel_handle_v1 handle.
+      </description>
+      <arg name="frame" type="new_id" interface="hyprland_toplevel_export_frame_v1"/>
+      <arg name="overlay_cursor" type="int"
+        summary="composite cursor onto the frame"/>
+      <arg name="handle" type="object" allow-null="false" summary="the zwlr_foreign_toplevel_handle_v1 handle of the toplevel to be captured"/>
+    </request>
+    <!-- End Version 2 -->
   </interface>
 
   <interface name="hyprland_toplevel_export_frame_v1" version="1">


### PR DESCRIPTION
This protocol will gather minor changes I'd like to make in Rev. 2 based on our experiences with rev 1.

The list of changes below is subject to change.

#### Introduce `capture_toplevel_with_wlr_toplevel_handle`
  The current system is extremely Hyprland-specific. I do not intend on leaving it like this, as it is not great for the Wayland ecosystem. This change would allow any compositor to more easily implement XDPH and this protocol.

  Rev.1 only has capture_toplevel which takes a uint32_t handle. This means the client has to somehow get a list of handles and what they refer to in a "magic" way. For now, it's done via `hyprctl`. 
  
  As mentioned previously, this is stupid and very hyprland-centric. Using `zwlr_foreign_toplevel_handle_v1` handles would make this compositor-agnostic, as long as the compositor implements the `zwlr_foreign_toplevel_v1`  and `hyprland_toplevel_export_v1` protocols.

  Server implementation is trivial, client implementation is trivial, however the communication between XDPH <-> picker has to be thought through (maybe a `--client-list="class::title[SEP]class::title"` arg?)
  

#### Related MRs
- https://github.com/hyprwm/xdg-desktop-portal-hyprland/pull/3
- https://github.com/hyprwm/Hyprland/pull/1203

