### PR TITLE
hyprland-global-shortcuts-v1: protocol implementation

### DIFF
--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -49,7 +49,7 @@
         The shortcut's keybinding shall be dealt with by the compositor.
       </description>
       <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
-      <arg name="id" type="uint" summary="a unique id for the shortcut"/>
+      <arg name="id" type="string" summary="a unique id for the shortcut"/>
       <arg name="app_id" type="string" summary="the app_id of the application requesting the shortcut"/>
       <arg name="description" type="string" summary="user-readable text describing what the shortcut does."/>
       <arg name="trigger_description" type="string" summary="user-readable text describing how to trigger the shortcut for the client to render."/>

--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -47,6 +47,8 @@
         A global shortcut is anonymous, meaning the app does not know what key(s) trigger it.
 
         The shortcut's keybinding shall be dealt with by the compositor.
+
+        In the case of a duplicate app_id + id combination, the already_taken protocol error is raised.
       </description>
       <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
       <arg name="id" type="string" summary="a unique id for the shortcut"/>
@@ -61,6 +63,11 @@
         appropriate destroy request has been called.
       </description>
     </request>
+
+    <enum name="error">
+      <entry name="already_taken" value="0"
+        summary="the app_id + id combination has already been registered."/>
+    </enum>
   </interface>
 
   <interface name="hyprland_global_shortcut_v1">

--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -31,8 +31,8 @@
   </copyright>
 
   <description summary="registering global shortcuts">
-    This protocol allows a client to register keystrokes that will be passed
-    to it regardless of its focus state.
+    This protocol allows a client to register triggerable actions,
+    meant to be global shortcuts.
   </description>
 
   <interface name="hyprland_global_shortcuts_manager_v1">
@@ -53,6 +53,13 @@
       <arg name="app_id" type="string" summary="the app_id of the application requesting the shortcut"/>
       <arg name="description" type="string" summary="user-readable text describing what the shortcut does."/>
       <arg name="trigger_description" type="string" summary="user-readable text describing how to trigger the shortcut for the client to render."/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
     </request>
   </interface>
 
@@ -88,5 +95,11 @@
       <arg name="tv_nsec" type="uint"
            summary="nanoseconds part of the timestamp"/>
     </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Destroys the shortcut. Can be sent at any time by the client.
+      </description>
+    </request>
   </interface>
 </protocol>

--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="hyprland_global_shortcuts_v1">
+  <copyright>
+    Copyright © 2022 Vaxry
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  </copyright>
+
+  <description summary="registering global shortcuts">
+    This protocol allows a client to register keystrokes that will be passed
+    to it regardless of its focus state.
+  </description>
+
+  <interface name="hyprland_global_shortcuts_manager_v1">
+    <description summary="manager to register global shortcuts">
+      This object is a manager which offers requests to create global shortcuts.
+    </description>
+
+    <request name="register_shortcut">
+      <description summary="register a shortcut">
+        Register a new global shortcut.
+
+        A keystroke is composed in a format of:
+        [MOD...+]KEY
+
+        for example:
+        SUPER+A or ALT+SHIFT+K
+
+        A keystroke is not required to have a MOD, although compositors might implement
+        security measures and reject such keybinds.
+      </description>
+      <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
+      <arg name="keystroke" type="string" summary="the keystroke"/>
+    </request>
+  </interface>
+
+  <interface name="hyprland_global_shortcut_v1">
+    <description summary="a shortcut">
+      This object represents a single shortcut.
+    </description>
+
+    <event name="status">
+      <description summary="keystroke status">
+        This is the first event sent by the compositor to indicate the status of this
+        global shortcut.
+
+        It will also be fired again shall the status of this shortcut change in the future.
+
+        If the status is not "ok", this hyprland_global_shortcut_v1 will not emit any
+        events other than a possible another status event if the status is changed.
+        <arg name="status" type="shortcut_status"/>
+      </description>
+    </event>
+
+    <event name="pressed">
+      <description summary="keystroke pressed">
+        The keystroke was pressed.
+      </description>
+    </event>
+
+    <event name="released">
+      <description summary="keystroke released">
+        The keystroke was released.
+      </description>
+    </event>
+  </interface>
+
+  <enum name="shortcut_status">
+    <entry name="ok" value="0" summary="This shortcut has been acknowledged and accepted by the compositor."/>
+    <entry name="rejected_policy" value="1" summary="The shortcut has been rejected by the compositor due to it violating the compositor's security policy."/>
+    <entry name="rejected_invalid" value="2" summary="The shortcut has been rejected by the compositor due to an error in parsing the keystroke string."/>
+    <entry name="rejected_other" value="3" summary="The shortcut has been rejected by the compositor due to an unspecified error."/>
+  </enum>
+</protocol>

--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -44,17 +44,15 @@
       <description summary="register a shortcut">
         Register a new global shortcut.
 
-        A keystroke is composed in a format of:
-        [MOD...+]KEY
+        A global shortcut is anonymous, meaning the app does not know what key(s) trigger it.
 
-        for example:
-        SUPER+A or ALT+SHIFT+K
-
-        A keystroke is not required to have a MOD, although compositors might implement
-        security measures and reject such keybinds.
+        The shortcut's keybinding shall be dealt with by the compositor.
       </description>
       <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
-      <arg name="keystroke" type="string" summary="the keystroke"/>
+      <arg name="id" type="uint" summary="a unique id for the shortcut"/>
+      <arg name="app_id" type="string" summary="the app_id of the application requesting the shortcut"/>
+      <arg name="description" type="string" summary="user-readable text describing what the shortcut does."/>
+      <arg name="trigger_description" type="string" summary="user-readable text describing how to trigger the shortcut for the client to render."/>
     </request>
   </interface>
 
@@ -62,19 +60,6 @@
     <description summary="a shortcut">
       This object represents a single shortcut.
     </description>
-
-    <event name="status">
-      <description summary="keystroke status">
-        This is the first event sent by the compositor to indicate the status of this
-        global shortcut.
-
-        It will also be fired again shall the status of this shortcut change in the future.
-
-        If the status is not "ok", this hyprland_global_shortcut_v1 will not emit any
-        events other than a possible another status event if the status is changed.
-        <arg name="status" type="shortcut_status"/>
-      </description>
-    </event>
 
     <event name="pressed">
       <description summary="keystroke pressed">
@@ -88,11 +73,4 @@
       </description>
     </event>
   </interface>
-
-  <enum name="shortcut_status">
-    <entry name="ok" value="0" summary="This shortcut has been acknowledged and accepted by the compositor."/>
-    <entry name="rejected_policy" value="1" summary="The shortcut has been rejected by the compositor due to it violating the compositor's security policy."/>
-    <entry name="rejected_invalid" value="2" summary="The shortcut has been rejected by the compositor due to an error in parsing the keystroke string."/>
-    <entry name="rejected_other" value="3" summary="The shortcut has been rejected by the compositor due to an unspecified error."/>
-  </enum>
 </protocol>

--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -35,7 +35,7 @@
     meant to be global shortcuts.
   </description>
 
-  <interface name="hyprland_global_shortcuts_manager_v1">
+  <interface name="hyprland_global_shortcuts_manager_v1" version="1">
     <description summary="manager to register global shortcuts">
       This object is a manager which offers requests to create global shortcuts.
     </description>
@@ -70,7 +70,7 @@
     </enum>
   </interface>
 
-  <interface name="hyprland_global_shortcut_v1">
+  <interface name="hyprland_global_shortcut_v1" version="1">
     <description summary="a shortcut">
       This object represents a single shortcut.
     </description>

--- a/protocols/hyprland-global-shortcuts-v1.xml
+++ b/protocols/hyprland-global-shortcuts-v1.xml
@@ -64,13 +64,29 @@
     <event name="pressed">
       <description summary="keystroke pressed">
         The keystroke was pressed.
+
+        tv_ values hold the timestamp of the occurrence.
       </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
     </event>
 
     <event name="released">
       <description summary="keystroke released">
         The keystroke was released.
+
+        tv_ values hold the timestamp of the occurrence.
       </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
     </event>
   </interface>
 </protocol>


### PR DESCRIPTION
This MR implements a new protocol `hyprland-global-shortcuts-v1`, which will be the basis for a D-Bus global shortcuts impl in XDPH.

Feel free to discuss and suggest changes, as usual.