### PR TITLE
meson: use existing system install if avaliable for installation(usually as dep)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ configure_file(
 
 hyprland_protocols = declare_dependency(
 	variables: {
-		'pkgdatadir': hyprland_protocols_srcdir,
+		'pkgdatadir': fs.is_dir('/usr/share/hyprland-protocols') ? '/usr/share/hyprland-protocols' : hyprland_protocols_srcdir,
 	},
 )
 


### PR DESCRIPTION
this is also how cmake handles it when it comes to installation
this variable is used by meson from xdph repo to determine
where is the protocol dir.
EDIT: typo