### PR TITLE
Add hyprland-toplevel-mapping-v1 to meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ fs = import('fs')
 
 protocols = {
   'hyprland-toplevel-export': ['v1'],
+  'hyprland-toplevel-mapping': ['v1'],
   'hyprland-global-shortcuts': ['v1'],
   'hyprland-focus-grab': ['v1'],
   'hyprland-ctm-control': ['v1'],


### PR DESCRIPTION
Hi,

I've just seen that I forgot to add the protocol to the meson.build file