### PR TITLE
Fix inefficient copy warning by using self instead of ./.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
       hyprland-protocols = final: prev: {
         hyprland-protocols = final.callPackage ./nix/default.nix {
           version = version + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+          inherit self;
         };
       };
     };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,12 +4,13 @@
   meson,
   ninja,
   version,
+  self,
 }:
 stdenv.mkDerivation {
   pname = "hyprland-protocols";
   inherit version;
 
-  src = ../.;
+  src = self;
 
   nativeBuildInputs = [meson ninja];
 


### PR DESCRIPTION
This PR fixes the inefficient copy warning identified by Determinate Nix.

## Changes
- Replace `src = ../.;` with `src = self;` in `nix/default.nix`
- Pass `self` as a parameter in the flake's callPackage

## Why this fix?
The warning appeared because using `./.` causes Nix to copy the entire source tree to the store again, which is inefficient. Using the flake's `self` input avoids this unnecessary copying and improves evaluation performance.

## Testing
- ✅ `nix flake check` passes
- ✅ `nix build` works correctly
- ✅ Warning is eliminated

References: https://determinate.systems/posts/changelog-determinate-nix-362/#track-down-and-fix-inefficient-double-copy-causes