### PR TITLE
input-capture-v1: add destroy destructor to the session interface

### DIFF
--- a/protocols/hyprland-input-capture-v1.xml
+++ b/protocols/hyprland-input-capture-v1.xml
@@ -35,7 +35,7 @@
 	This protocol is a bridge of the XDG input capture to the compositor.
   </description>
 
-  <interface name="hyprland_input_capture_manager_v1" version="1">
+  <interface name="hyprland_input_capture_manager_v1" version="2">
     <description summary="manage input capture sessions">
       This interface allows to create an input capture session.
     </description>
@@ -50,7 +50,7 @@
     </request>
   </interface>
 
- <interface name="hyprland_input_capture_v1" version="1">
+ <interface name="hyprland_input_capture_v1" version="2">
     <description summary="close reproduction of the xdg input capture portal">
 	  Interface that is used to create barrier, and trigger capture and release of the pointer.
 	  The inputs are sent through an EIS socket, when the cursor hit a barrier.
@@ -142,6 +142,16 @@
         type="uint"
         summary="same activation id of the latest activated event" />
     </event>
+
+	<request name="destroy" type="destructor" since="2">
+	  <description summary="destroy the session">
+	    Destroy the input capture session.
+
+	    Any barriers registered by this session are removed, input capturing is
+	    stopped, and the eis socket associated with this session is closed by the
+	    compositor. The client must not use the object after this request.
+	  </description>
+	</request>
 
     <enum name="error">
       <entry name="invalid_barrier_id" value="0"


### PR DESCRIPTION
This implements a destroy lifecycle on `hyprland_input_capture_v1`, the only interface
here without a destructor.

Part 1 of 3 needed for hyprwm/xdg-desktop-portal-hyprland#419, leaking file descriptors
from InputCapture.
Needs to merge right after https://github.com/hyprwm/xdg-desktop-portal-hyprland/pull/421, which gates the auto-generated destructor by
version.

### Validation

Scanner clean, install reports 0.8.0. Built clean and installed all 3 PRs in an Arch VM as well as the latest main/master and then verified the leaking flow from #419.

| | before | after |
|---|---|---|
| bind version | 1 | 2 |
| teardown traffic | `disable` only | `destroy` only |
| `eis-*.lock` | one per session, never freed | stays at 0 |
| protocol errors | none | none |

Object IDs get reused afterwards, so the compositor is genuinely freeing them.

### Disclosure

Agent implemented and verified in VM, with oversight and review from me before publishing.
